### PR TITLE
Fix mapped IPv4 address regex

### DIFF
--- a/ext/bootstrap.js
+++ b/ext/bootstrap.js
@@ -129,7 +129,7 @@ var httpRequestObserver =
       
       /* If the address matches ::xxxx:xxxx, convert it to ::nnn.nnn.nnn.nnn format. */
       if (Preferences.get("extensions.ipvfox.detectEmbeddedv4")) {
-        if (matches = newentry.address.match(/^([0-9a-f:]+?)::([0-9a-f]{1,4}):([0-9a-f]{1,4})/)) {
+        if (matches = newentry.address.match(/^([0-9a-f:]+?)::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)) {
           function zeroPad(num,count) {
             var numZeropad = num + '';
             while(numZeropad.length < count) {


### PR DESCRIPTION
regex needed end anchor for proper detection. Was causing false positives on addresses with double colons earlier in address, eg:
2600:3c03::f03c:91ff:fe73:b7f3 was displaying as 2600:3c03::240.60.145.255
