### PR TITLE
French locale

### DIFF
--- a/ext/chrome.manifest
+++ b/ext/chrome.manifest
@@ -2,3 +2,4 @@ content ipvfox chrome/
 skin    ipvfox classic/1.0 skin/
 locale  ipvfox en-US locale/en-US/
 locale  ipvfox en-GB locale/en-GB/
+locale  ipvfox fr-FR locale/fr-FR/

--- a/ext/locale/fr-FR/ipvfox.properties
+++ b/ext/locale/fr-FR/ipvfox.properties
@@ -1,0 +1,8 @@
+# Strings for NAT64 detection in about:addons.
+Refresh=Rafraîchir
+
+No attempt made=Aucune tentative
+Resolving...=Résolution en cours…
+Error resolving=Erreur lors de la résolution de "%S"
+None=Aucun
+Unknown=Inconnu

--- a/ext/locale/fr-FR/options.dtd
+++ b/ext/locale/fr-FR/options.dtd
@@ -1,0 +1,8 @@
+<!ENTITY alwaysShow "Aficher l'icône dans la barre d'adresse même quand le bouton de la barre d'outils est utilisé">
+<!ENTITY convertEmbedded "Essayer de détecter et convertir les adresses v4 intégrées">
+<!ENTITY convertEmbedded.desc "e.g. 2001:db8::c000:201 to 2001:db8::192.0.2.1">
+<!ENTITY autoDetectNAT64 "Essayer de détecter les préfixes NAT64 au démarrage">
+<!ENTITY autoDetectedPrefixes "Préfixes NAT64 détectés automatiquement">
+<!ENTITY manualPrefixes "Préfixes NAT64 manuels">
+<!ENTITY manualPrefixes.desc "Liste de préfixes séparés par un espace à considérer comme v4.">
+<!ENTITY useGrayscaleButtons "Utiliser des icônes en nuances de gris (Firefox 35+ uniquement)">


### PR DESCRIPTION
Here is a French translation.
I don't know why, but the strings in *ipvfox.properties* are still displayed in English...